### PR TITLE
Open PR tabs sequentially

### DIFF
--- a/src/dependabot-pull-dom.ts
+++ b/src/dependabot-pull-dom.ts
@@ -1,6 +1,6 @@
+import { WAIT_PERIODS } from './github/constants';
 import { isDependabotPr, shouldMerge } from './github/pull';
 import { SELECTORS } from './github/selectors';
-import { getRandomWaitBetween } from './utils/time';
 
 const writeMergeComment = () => {
   const commentField: HTMLTextAreaElement | null = document.querySelector(
@@ -23,7 +23,7 @@ const writeMergeComment = () => {
       if (button.innerHTML.includes(SELECTORS.GITHUB_COMMENT_BUTTON_TEXT)) {
         setTimeout(() => {
           button.click();
-        }, getRandomWaitBetween(2000, 3000));
+        }, WAIT_PERIODS.CLICK_BUTTON);
       }
     });
   }
@@ -32,7 +32,7 @@ const writeMergeComment = () => {
 const closeCurrentTab = () => {
   setTimeout(() => {
     window.close();
-  }, getRandomWaitBetween(8000, 12000));
+  }, WAIT_PERIODS.CLOSE_TAB);
 };
 
 window.addEventListener('load', () => {

--- a/src/github/constants.ts
+++ b/src/github/constants.ts
@@ -1,5 +1,12 @@
 export const MERGE_QUERY_PARAM = 'MERGE_DEPENDABOT_PR';
 
+export const WAIT_PERIODS = {
+  CLICK_BUTTON: 500,
+  CLOSE_TAB: 7000,
+  OPEN_NEW_TAB: 3000,
+};
+
 export default {
   MERGE_QUERY_PARAM,
+  WAIT_PERIODS,
 };

--- a/src/github/pulls.ts
+++ b/src/github/pulls.ts
@@ -1,4 +1,5 @@
-import { MERGE_QUERY_PARAM } from './constants';
+import { wait } from '../utils/time';
+import { MERGE_QUERY_PARAM, WAIT_PERIODS } from './constants';
 import { SELECTORS } from './selectors';
 
 const getDependabotPrs = (prElements: Element[]): Element[] => prElements
@@ -9,10 +10,17 @@ const getLinks = (prElements: Element[]): string[] => prElements
   .filter((link) => typeof link === 'string')
   .map((link) => `${link}?${MERGE_QUERY_PARAM}=true`);
 
-const openLinksTonewTabs = (links: string[]) => {
-  links.forEach((link) => {
-    window.open(link);
-  });
+/**
+ * Opens links to new tabs.
+ * Requires a little wait between opens, so that
+ * the one that opens remains "active" in view for a bit.
+ */
+const openLinksTonewTabs = async (links: string[]) => {
+  for (let i = 0; i < links.length; i += 1) {
+    window.open(links[i]);
+    // eslint-disable-next-line no-await-in-loop
+    await wait(WAIT_PERIODS.OPEN_NEW_TAB);
+  }
 };
 
 export const hasDependabotPrs = (): boolean => {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -2,6 +2,10 @@ export const getRandomWaitBetween = (min: number, max: number): number => (
   Math.floor(Math.random() * (max - min) + min)
 );
 
+// eslint-disable-next-line no-promise-executor-return
+export const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export default {
   getRandomWaitBetween,
+  wait,
 };


### PR DESCRIPTION
Github client side codes seems to need tab to be "active" to properly kick off the processes. Instead of openinig them all at once, open them sequentially and give it couple of seconds to process. Seems to work.

Obviously much slower than adding all comments at once. May need to tweak how fast it should be.

Closes #23